### PR TITLE
Add functionality to implement personal transports

### DIFF
--- a/common/map.c
+++ b/common/map.c
@@ -1280,9 +1280,6 @@ mapstruct *mapfile_load(const char *map, int flags) {
     /* In case other objects press some buttons down */
     update_buttons(m);
 
-    /* Handle for map load event */
-    execute_global_event(EVENT_MAPLOAD, m);
-
     if (!(flags & MAP_STYLE))
         apply_auto_fix(m); /* Chests which open as default */
 
@@ -1920,6 +1917,9 @@ mapstruct *ready_map_name(const char *name, int flags) {
             m->last_reset_time = seconds();
         }
     }
+
+    execute_global_event(EVENT_MAPLOAD, m);
+
     return m;
 }
 

--- a/common/map.c
+++ b/common/map.c
@@ -1673,6 +1673,15 @@ static void free_all_objects(mapstruct *m) {
     int i, j;
     object *op;
 
+    /* I came up with this event as a way to gather a reference from objects
+     * right before they are freed from the map (context was the creation of a
+     * tracking system for unique objects through a plugin).  EVENT_MAPUNLOAD
+     * and EVENT_MAPRESET would not do, because when the map is reset, these
+     * events are fired after the freeing of objects (an unecessary side-effect
+     * of using the save_map function).
+     */
+    execute_global_event(EVENT_FREE_OBJECTS, m);
+
     for (i = 0; i < MAP_WIDTH(m); i++)
         for (j = 0; j < MAP_HEIGHT(m); j++) {
             object *previous_obj = NULL;

--- a/include/plugin.h
+++ b/include/plugin.h
@@ -99,7 +99,8 @@
 #define EVENT_REMOVE    24 /**< A Player character has been removed.           */
 #define EVENT_SHOUT     25 /**< A player 'shout' something.                    */
 #define EVENT_TELL      26 /**< A player 'tell' something.                     */
-#define NR_EVENTS 36
+#define EVENT_FREE_OBJECTS  36 /**< free_all_objects(map)                      */
+#define NR_EVENTS 37
 
 #include <stdarg.h>
 

--- a/include/plugin.h
+++ b/include/plugin.h
@@ -83,6 +83,7 @@
 /*******************************************************************************/
 #define EVENT_BORN      14 /**< A new character has been created.              */
 #define EVENT_CLOCK     15 /**< Global time event.                             */
+#define EVENT_SERVER_SHUTDOWN 35 /**< Server shutdown.                         */
 #define EVENT_CRASH     16 /**< Triggered when the server crashes. Not recursive */
 #define EVENT_GKILL     18 /**< Triggered when anything got killed by anyone.  */
 #define EVENT_KICK      28 /**< A player was Kicked by a DM                    */
@@ -98,7 +99,7 @@
 #define EVENT_REMOVE    24 /**< A Player character has been removed.           */
 #define EVENT_SHOUT     25 /**< A player 'shout' something.                    */
 #define EVENT_TELL      26 /**< A player 'tell' something.                     */
-#define NR_EVENTS 35
+#define NR_EVENTS 36
 
 #include <stdarg.h>
 

--- a/plugins/cfpython/cfpython.c
+++ b/plugins/cfpython/cfpython.c
@@ -1245,6 +1245,7 @@ static void initConstants(PyObject *module) {
         /** Global events. */
         { "BORN", EVENT_BORN },
         { "CLOCK", EVENT_CLOCK },
+        { "SERVER_SHUTDOWN", EVENT_SERVER_SHUTDOWN },
         { "CRASH", EVENT_CRASH },
         { "GKILL", EVENT_GKILL },
         { "KICK", EVENT_KICK },
@@ -1535,6 +1536,7 @@ CF_PLUGIN void cfpython_runPluginCommand(object *op, const char *params) {
 static int GECodes[] = {
     EVENT_BORN,
     EVENT_CLOCK,
+    EVENT_SERVER_SHUTDOWN,
     EVENT_PLAYER_DEATH,
     EVENT_GKILL,
     EVENT_LOGIN,
@@ -1555,6 +1557,7 @@ static int GECodes[] = {
 static const char* GEPaths[] = {
     "born",
     "clock",
+    "server_shutdown",
     "death",
     "gkill",
     "login",
@@ -1711,6 +1714,9 @@ CF_PLUGIN int cfpython_globalEventListener(int *type, ...) {
         break;
 
     case EVENT_CLOCK:
+        break;
+
+    case EVENT_SERVER_SHUTDOWN:
         break;
 
     case EVENT_MAPRESET:

--- a/plugins/cfpython/cfpython.c
+++ b/plugins/cfpython/cfpython.c
@@ -1261,6 +1261,7 @@ static void initConstants(PyObject *module) {
         { "REMOVE", EVENT_REMOVE },
         { "SHOUT", EVENT_SHOUT },
         { "TELL", EVENT_TELL },
+        { "FREE_OBJECTS", EVENT_FREE_OBJECTS },
         { NULL, 0 }
     };
 
@@ -1551,6 +1552,7 @@ static int GECodes[] = {
     EVENT_KICK,
     EVENT_MAPUNLOAD,
     EVENT_MAPLOAD,
+    EVENT_FREE_OBJECTS,
     0  
 };
 
@@ -1572,6 +1574,7 @@ static const char* GEPaths[] = {
     "kick",
     "mapunload",
     "mapload",
+    "free_objects",
     NULL  
 };
 
@@ -1738,6 +1741,10 @@ CF_PLUGIN int cfpython_globalEventListener(int *type, ...) {
         break;
 
     case EVENT_MAPLOAD:
+        context->who = Crossfire_Map_wrap(va_arg(args, mapstruct *));
+        break;
+
+    case EVENT_FREE_OBJECTS:
         context->who = Crossfire_Map_wrap(va_arg(args, mapstruct *));
         break;
     }

--- a/plugins/cfpython/cfpython_object.c
+++ b/plugins/cfpython/cfpython_object.c
@@ -308,6 +308,11 @@ static PyObject *Object_GetTitle(Crossfire_Object *whoptr, void *closure) {
     return Py_BuildValue("s", cf_object_get_sstring_property(whoptr->obj, CFAPI_OBJECT_PROP_TITLE));
 }
 
+static PyObject *Object_GetCustomName(Crossfire_Object *whoptr, void *closure) {
+    EXISTCHECK(whoptr);
+    return Py_BuildValue("s", cf_object_get_sstring_property(whoptr->obj, CFAPI_OBJECT_PROP_CUSTOM_NAME));
+}
+
 static PyObject *Object_GetRace(Crossfire_Object *whoptr, void *closure) {
     EXISTCHECK(whoptr);
     return Py_BuildValue("s", cf_object_get_sstring_property(whoptr->obj, CFAPI_OBJECT_PROP_RACE));
@@ -1037,6 +1042,17 @@ static int Object_SetTitle(Crossfire_Object *whoptr, PyObject *value, void *clos
         return -1;
 
     cf_object_set_string_property(whoptr->obj, CFAPI_OBJECT_PROP_TITLE, val);
+    return 0;
+}
+
+static int Object_SetCustomName(Crossfire_Object *whoptr, PyObject *value, void *closure) {
+    char *val;
+
+    EXISTCHECK_INT(whoptr);
+    if (!PyArg_Parse(value, "s", &val))
+        return -1;
+
+    cf_object_set_string_property(whoptr->obj, CFAPI_OBJECT_PROP_CUSTOM_NAME, val);
     return 0;
 }
 
@@ -2655,6 +2671,7 @@ static PyGetSetDef Object_getseters[] = {
     { "Name",           (getter)Object_GetName,         (setter)Object_SetName, NULL, NULL },
     { "NamePl",         (getter)Object_GetNamePl,       (setter)Object_SetNamePl, NULL, NULL },
     { "Title",          (getter)Object_GetTitle,        (setter)Object_SetTitle, NULL, NULL },
+    { "CustomName",     (getter)Object_GetCustomName,   (setter)Object_SetCustomName, NULL, NULL },
     { "Race",           (getter)Object_GetRace,         (setter)Object_SetRace, NULL, NULL },
     { "Skill",          (getter)Object_GetSkill,        (setter)Object_SetSkill, NULL, NULL },
     { "Map",            (getter)Object_GetMap,          (setter)Object_SetMap, NULL, NULL },

--- a/plugins/cfpython/cfpython_object.c
+++ b/plugins/cfpython/cfpython_object.c
@@ -861,6 +861,11 @@ static PyObject *Object_GetExists(Crossfire_Object *whoptr, void *closure) {
     }
 }
 
+static PyObject *Object_GetRemoved(Crossfire_Object *whoptr, void *closure) {
+    EXISTCHECK(whoptr);
+    return Py_BuildValue("i", cf_object_get_flag(whoptr->obj, FLAG_REMOVED));
+}
+
 static PyObject *Object_GetEnv(Crossfire_Object *whoptr, void *closure) {
     EXISTCHECK(whoptr);
     return Crossfire_Object_wrap(cf_object_get_object_property(whoptr->obj, CFAPI_OBJECT_PROP_ENVIRONMENT));
@@ -2777,6 +2782,7 @@ static PyGetSetDef Object_getseters[] = {
     { "Archetype",      (getter)Object_GetArchetype,    NULL, NULL, NULL },
     { "OtherArchetype", (getter)Object_GetOtherArchetype,NULL, NULL, NULL },
     { "Exists",         (getter)Object_GetExists,       NULL, NULL, NULL },
+    { "Removed",        (getter)Object_GetRemoved,      NULL, NULL, NULL },
     { "NoSave",         (getter)Object_GetNoSave,       (setter)Object_SetNoSave, NULL, NULL },
     { "Env",            (getter)Object_GetEnv,          NULL, NULL, NULL },
     { "MoveType",       (getter)Object_GetMoveType,     (setter)Object_SetMoveType, NULL, NULL },

--- a/random_maps/style.c
+++ b/random_maps/style.c
@@ -155,6 +155,7 @@ mapstruct *load_style_map(char *style_name)
         style_map->next = styles;
         styles = style_map;
     }
+    execute_global_event(EVENT_MAPLOAD, style_map);
     return style_map;
 }
 

--- a/server/plugins.c
+++ b/server/plugins.c
@@ -567,6 +567,15 @@ int execute_global_event(int eventcode, ...) {
                 cp->gevent[eventcode](&rt, eventcode, map);
         }
         break;
+
+    case EVENT_FREE_OBJECTS:
+        /*FREE_OBJECTS: map*/
+        map = va_arg(args, mapstruct *);
+        for (cp = plugins_list; cp != NULL; cp = cp->next) {
+            if (cp->gevent[eventcode] != NULL)
+                cp->gevent[eventcode](&rt, eventcode, map);
+        }
+        break;
     }
     va_end(args);
     return 0;

--- a/server/plugins.c
+++ b/server/plugins.c
@@ -415,6 +415,14 @@ int execute_global_event(int eventcode, ...) {
         }
         break;
 
+    case EVENT_SERVER_SHUTDOWN:
+        /*SERVER_SHUTDOWN: -*/
+        for (cp = plugins_list; cp != NULL; cp = cp->next) {
+            if (cp->gevent[eventcode] != NULL)
+                cp->gevent[eventcode](&rt, eventcode);
+        }
+        break;
+
     case EVENT_CRASH:
         for (cp = plugins_list; cp != NULL; cp = cp->next) {
             if (cp->gevent[eventcode] != NULL)

--- a/server/server.c
+++ b/server/server.c
@@ -520,6 +520,7 @@ static void enter_fixed_template_map(object *pl, object *exit_ob) {
      */
     strlcpy(new_map->path, new_map_name, sizeof(new_map->path));
     new_map->is_template = 1;
+    execute_global_event(EVENT_MAPLOAD, new_map);
     enter_map(pl, new_map, EXIT_X(exit_ob), EXIT_Y(exit_ob));
 }
 
@@ -595,6 +596,8 @@ static void enter_random_template_map(object *pl, object *exit_ob) {
 /**
  * Player is entering a unique map.
  *
+ * Note: This function is messy.
+ *
  * @param op
  * player.
  * @param exit_ob
@@ -610,6 +613,7 @@ static void enter_unique_map(object *op, object *exit_ob) {
         if (!newmap) {
             create_pathname(EXIT_PATH(exit_ob), path, sizeof(path));
             newmap = mapfile_load(path, MAP_PLAYER_UNIQUE);
+            execute_global_event(EVENT_MAPLOAD, newmap);
         }
     } else { /* relative directory */
         char reldir[HUGE_BUF], tmpc[HUGE_BUF], *cp;
@@ -629,6 +633,7 @@ static void enter_unique_map(object *op, object *exit_ob) {
             if (!newmap) {
                 create_pathname(path_combine_and_normalize(reldir, EXIT_PATH(exit_ob), tmpc, sizeof(tmpc)), path, sizeof(path));
                 newmap = mapfile_load(path, MAP_PLAYER_UNIQUE);
+                execute_global_event(EVENT_MAPLOAD, newmap);
             }
         } else {
             /* The exit is unique, but the map we are coming from is not unique.  So

--- a/server/server.c
+++ b/server/server.c
@@ -1359,6 +1359,7 @@ int forbid_play(void) {
 }
 
 static void do_shutdown(void) {
+    execute_global_event(EVENT_SERVER_SHUTDOWN);
     draw_ext_info(NDI_UNIQUE | NDI_ALL, 5, NULL, MSG_TYPE_ADMIN,
             MSG_TYPE_ADMIN_DM, "The server has shut down.");
 


### PR DESCRIPTION
Exposed to CFPython:

- obj.CustomName
- obj.Removed

New events:

- `SERVER_SHUTDOWN`: When shutting down the server.
- `FREE_OBJECTS`: When objects are to be freed from a map.

Modified events:

- `EVENT_MAPLOAD`: Modified to trigger only when map is fully loaded (along with unique objects and such).

Part of: https://github.com/TitusCF/HeroWorld/pull/7